### PR TITLE
wip: headquarters

### DIFF
--- a/src/app/(authorized)/admin/users/data.tsx
+++ b/src/app/(authorized)/admin/users/data.tsx
@@ -1,4 +1,8 @@
-import { UserRoleText, UserStatusText } from '@/entities/user/ui/user-text';
+import {
+  UserNicknameText,
+  UserRoleText,
+  UserStatusText,
+} from '@/entities/user/ui/user-text';
 
 import { ROUTES } from '@/shared/config/routes';
 import { User, UserStatus } from '@/shared/sdk/types';
@@ -20,7 +24,10 @@ export const columns: ColumnDef<User>[] = [
       return (
         <div>
           <Link href={ROUTES.user.users.id(row.original.id)}>
-            {row.original.nickname}
+            <UserNicknameText
+              user={row.original}
+              sideType={row.original.squad?.side?.type}
+            />
           </Link>
         </div>
       );

--- a/src/app/(authorized)/profile/page.tsx
+++ b/src/app/(authorized)/profile/page.tsx
@@ -97,7 +97,10 @@ const ProfilePage = observer(() => {
                   <div className='flex flex-col gap-4'>
                     <div className='flex items-center gap-2'>
                       <UserIcon className='size-6' />
-                      <UserNicknameText user={profile.user} />
+                      <UserNicknameText
+                        user={profile.user}
+                        sideType={profile?.user?.squad?.side?.type}
+                      />
                     </div>
                     <div className='flex items-center  gap-2'>
                       <ShieldUserIcon className='size-6' />

--- a/src/app/(authorized)/profile/page.tsx
+++ b/src/app/(authorized)/profile/page.tsx
@@ -44,7 +44,7 @@ const ProfilePage = observer(() => {
   return (
     <Layout>
       <Hero />
-      <ChangeAvatarModal model={profile.avatar} />
+      <ChangeAvatarModal model={profile.avatar} autoInputClick />
       <div className='max-w-5xl bg-card/80 w-full mx-auto my-4'>
         <div className='flex items-center gap-2'>
           <div className='flex flex-col gap-2'>
@@ -60,6 +60,7 @@ const ProfilePage = observer(() => {
                     Змінити
                   </Button>
                   <Image
+                    className='rounded-lg'
                     src={profile.user?.avatar?.url || '/images/avatar.jpg'}
                     width={256}
                     height={256}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,14 @@
   --color-destructive: #ff0000;
 }
 
+@utility paper {
+  background-color: var(--color-card);
+  border-color: var(--color-primary);
+  border-width: 1px;
+  border-style: solid;
+  border-radius: var(--radius-sm)
+}
+
 * {
   scroll-behavior: smooth;
   box-sizing: border-box;

--- a/src/app/rules/page.tsx
+++ b/src/app/rules/page.tsx
@@ -5,7 +5,7 @@ import { Layout } from '@/widgets/layout';
 import { FC, PropsWithChildren } from 'react';
 
 const RuleCategory: FC<PropsWithChildren> = ({ children }) => (
-  <div className='flex flex-col gap-4 bg-card/80 py-4 rounded-sm'>{children}</div>
+  <div className='flex flex-col gap-4 py-4 paper'>{children}</div>
 );
 const RuleTitle: FC<PropsWithChildren<{ id?: string }>> = ({
   children,
@@ -77,7 +77,7 @@ const RuleMenu = () => {
   ];
 
   return (
-    <div className='flex flex-col bg-card/80 min-w-1/4 h-fit sticky top-20 shadow-2xl max-lg:hidden rounded-sm'>
+    <div className='flex flex-col min-w-1/4 h-fit sticky top-20 shadow-2xl max-lg:hidden paper'>
       <h2 className='text-lg mt-4 mb-1 font-bold text-center'>Розділи</h2>
       <div className='flex flex-col'>
         {ruleCategories.map((category) => (
@@ -100,7 +100,7 @@ const RulesPage = () => {
       <h1 className='text-2xl font-bold text-center my-4'>Правила проекту</h1>
       <div className=' max-md:p-0 max-md:m-0 min-lg:container mx-auto flex gap-4'>
         <RuleMenu />
-        <div className='w-full mx-auto mb-1'>
+        <div className='w-full mx-auto mb-1 flex flex-col gap-8'>
           <RuleCategory>
             <RuleTitle id='1'>
               📜 Правила спілкування на ігрових ресурсах проєкту "ARMA 3 VTG"

--- a/src/app/squads/page.tsx
+++ b/src/app/squads/page.tsx
@@ -21,7 +21,7 @@ const SquadsPage = async () => {
   );
 
   return (
-    <Layout className='w-full bg-card/80 mx-auto my-4 p-4 max-w-4xl'>
+    <Layout className='w-full mx-auto my-4 p-4 max-w-4xl paper'>
       <h1 className='text-lg font-bold text-center'>Загони проекту</h1>
 
       <Suspense fallback={<LoaderIcon className='w-4 h-4 animate-spin' />}>

--- a/src/entities/user/ui/user-squad/index.tsx
+++ b/src/entities/user/ui/user-squad/index.tsx
@@ -27,10 +27,10 @@ export const UserSquad: FC<{
     <div className='flex flex-col gap-2'>
       <div className='flex items-center gap-2'>
         <Image
-          src='/images/logo.webp'
+          src={squad.logo?.url || '/images/logo.webp'}
           alt={squad.name}
-          width={32}
-          height={32}
+          width={128}
+          height={128}
         />
       </div>
     </div>

--- a/src/entities/user/ui/user-text/index.tsx
+++ b/src/entities/user/ui/user-text/index.tsx
@@ -14,6 +14,7 @@ export const UserNicknameText: FC<{
 
   if ((tag && sideType) || user?.squad?.name) {
     const type = sideType || user?.squad?.side?.type;
+
     return (
       <span className={className}>
         <span

--- a/src/features/auth/forgot-password-confirm/ui.tsx
+++ b/src/features/auth/forgot-password-confirm/ui.tsx
@@ -26,6 +26,21 @@ const ForgotPasswordConfirmForm: FC<{
   const schema = yup.object().shape({
     password: yup
       .string()
+      .test('password', 'Пароль повинен містити хоча б одну цифру', (value) => {
+        return /\d/.test(value || '');
+      })
+      .test('password', 'Пароль повинен містити хоча б одну букву', (value) => {
+        return /[a-zA-Z]/.test(value || '');
+      })
+      .test('password', 'Пароль повинен містити хоча б один спеціальний символ', (value) => {
+        return /[!@#$%^&*]/.test(value || '');
+      })
+      .test('password', 'Пароль повинен містити хоча б одну велику букву', (value) => {
+        return /[A-Z]/.test(value || '');
+      })
+      .test('password', 'Пароль повинен містити хоча б одну маленьку букву', (value) => {
+        return /[a-z]/.test(value || '');
+      })
       .min(8, 'Пароль повинен бути не менше 8 символів')
       .required("Обов'язкове поле"),
     confirmPassword: yup

--- a/src/features/auth/forgot-password-confirm/ui.tsx
+++ b/src/features/auth/forgot-password-confirm/ui.tsx
@@ -83,7 +83,7 @@ const ForgotPasswordConfirmForm: FC<{
           render={({ field }) => (
             <Input
               {...field}
-              placeholder='Пароль'
+              label='Пароль'
               type='password'
               error={form.formState.errors.password?.message}
             />
@@ -96,7 +96,7 @@ const ForgotPasswordConfirmForm: FC<{
           render={({ field }) => (
             <Input
               {...field}
-              placeholder='Повторіть пароль'
+              label='Повторіть пароль'
               type='password'
               error={form.formState.errors.confirmPassword?.message}
             />

--- a/src/features/auth/forgot-password/ui.tsx
+++ b/src/features/auth/forgot-password/ui.tsx
@@ -87,7 +87,7 @@ const ForgotPasswordForm: FC<{
             render={({ field }) => (
               <Input
                 {...field}
-                placeholder='Email'
+                label='Email'
                 error={form.formState.errors.email?.message}
               />
             )}

--- a/src/features/auth/login/ui.tsx
+++ b/src/features/auth/login/ui.tsx
@@ -21,7 +21,6 @@ const LoginForm: FC<{
   const schema = yup.object().shape({
     email: yup
       .string()
-      .email('Неправильний формат email')
       .required("Обов'язкове поле"),
     password: yup.string().required("Обов'язкове поле"),
   });
@@ -71,7 +70,7 @@ const LoginForm: FC<{
             <Input
               {...field}
               autoFocus
-              label='Email'
+              label='Нікнейм або email'
               error={form.formState.errors.email?.message}
             />
           )}

--- a/src/features/auth/login/ui.tsx
+++ b/src/features/auth/login/ui.tsx
@@ -56,7 +56,7 @@ const LoginForm: FC<{
   return (
     <div
       className={classNames(
-        'max-w-lg flex flex-col border border-primary bg-card p-4',
+        'max-w-lg flex flex-col border border-primary bg-card p-4 rounded-sm',
         className
       )}>
       <h2 className='text-2xl font-bold mb-4 text-center'>Увійти</h2>
@@ -70,7 +70,8 @@ const LoginForm: FC<{
           render={({ field }) => (
             <Input
               {...field}
-              placeholder='Email'
+              autoFocus
+              label='Email'
               error={form.formState.errors.email?.message}
             />
           )}
@@ -83,7 +84,7 @@ const LoginForm: FC<{
             <Input
               {...field}
               type='password'
-              placeholder='Пароль'
+              label='Пароль'
               error={form.formState.errors.password?.message}
             />
           )}

--- a/src/features/schedule/index.tsx
+++ b/src/features/schedule/index.tsx
@@ -5,7 +5,8 @@ import { FC } from 'react';
 
 export const ScheduleInfo: FC<{
   className?: string;
-}> = ({ className }) => {
+  version?: 'full' | 'short';
+}> = ({ className, version = 'full' }) => {
   return (
     <div
       className={cn(
@@ -13,12 +14,14 @@ export const ScheduleInfo: FC<{
         className
       )}>
       <div className='flex gap-2 items-center'>
-        <CalendarIcon className='size-4' />
-        <span>П&apos;ятниця та неділя</span>
+        <CalendarIcon className='size-4 shrink-0' />
+        {version === 'full' && <span className='whitespace-nowrap'>П&apos;ятниця та неділя</span>}
+        {version === 'short' && <span className='text-xs whitespace-nowrap'>ПТ та НД</span>}
       </div>
       <div className='flex gap-2 items-center'>
-        <Clock4Icon className='size-4' />
-        <span>19:30 по Києву</span>
+        <Clock4Icon className='size-4 shrink-0' />
+        {version === 'full' && <span className='whitespace-nowrap'>19:30 по Києву</span>}
+        {version === 'short' && <span className='text-xs whitespace-nowrap'>19:30</span>}
       </div>
     </div>
   );

--- a/src/features/servers/manage/ui.tsx
+++ b/src/features/servers/manage/ui.tsx
@@ -125,7 +125,7 @@ const ManageServerModal: FC<
                     <Input
                       {...field}
                       autoFocus
-                      placeholder='Назва сервера'
+                      label='Назва сервера'
                       error={form.formState.errors.name?.message}
                     />
                   )}
@@ -136,7 +136,7 @@ const ManageServerModal: FC<
                   render={({ field }) => (
                     <Input
                       {...field}
-                      placeholder='IP сервера'
+                      label='IP сервера'
                       error={form.formState.errors.ip?.message}
                     />
                   )}
@@ -148,7 +148,7 @@ const ManageServerModal: FC<
                   render={({ field }) => (
                     <NumericInput
                       {...field}
-                      placeholder='Порт сервера'
+                      label='Порт сервера'
                       maxLength={4}
                       error={form.formState.errors.port?.message}
                     />

--- a/src/features/social/ui.tsx
+++ b/src/features/social/ui.tsx
@@ -27,8 +27,8 @@ const socials = [
 
 const Social: FC<{
   className?: string;
-  size?: number;
-}> = ({ className, size = 24 }) => {
+  iconClassName?: string;
+}> = ({ className, iconClassName = 'size-6' }) => {
   return (
     <div className={cn('flex gap-6', className)}>
       {socials.map((social) => (
@@ -38,7 +38,13 @@ const Social: FC<{
           target='_blank'
           rel='noopener noreferrer'
           className='hover:scale-110 transition-transform'>
-          <Image src={social.src} alt={social.alt} width={size} height={size} />
+          <Image
+            src={social.src}
+            alt={social.alt}
+            width={24}
+            height={24}
+            className={iconClassName}
+          />
         </a>
       ))}
     </div>

--- a/src/features/squads/manage/ui.tsx
+++ b/src/features/squads/manage/ui.tsx
@@ -18,7 +18,7 @@ import {
 } from 'react';
 import { ManageSquadModel } from './model';
 import { Input } from '@/shared/ui/atoms/input';
-import { CreateSquadDto, Squad } from '@/shared/sdk/types';
+import { CreateSquadDto, Squad, UpdateSquadDto } from '@/shared/sdk/types';
 
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -104,13 +104,39 @@ const ManageSquadModal: FC<
 
     const onSubmit = async (data: CreateSquadDto) => {
       if (isEdit) {
-        model.updateSquad(
-          {
-            ...data,
-            id: model.modal.payload?.squad?.id || '',
-          },
-          onUpdateSuccess
-        );
+        const dto: UpdateSquadDto = {
+          id: model.modal.payload?.squad?.id || '',
+        };
+
+        if (data.activeCount !== model.modal.payload?.squad?.activeCount) {
+          dto.activeCount = data.activeCount;
+        }
+
+        if (data.name !== model.modal.payload?.squad?.name) {
+          dto.name = data.name;
+        }
+
+        if (data.tag !== model.modal.payload?.squad?.tag) {
+          dto.tag = data.tag;
+        }
+
+        if (data.description !== model.modal.payload?.squad?.description) {
+          dto.description = data.description;
+        }
+
+        if (data.leaderId !== model.modal.payload?.squad?.leader?.id) {
+          dto.leaderId = data.leaderId;
+        }
+
+        if (data.sideId !== model.modal.payload?.squad?.side?.id) {
+          dto.sideId = data.sideId;
+        }
+
+        if (file) {
+          dto.logo = file;
+        }
+
+        model.updateSquad(dto, onUpdateSuccess);
       } else {
         model.createSquad(
           { ...data, logo: file || undefined },
@@ -137,8 +163,8 @@ const ManageSquadModal: FC<
           'description',
           model.modal.payload?.squad?.description || ''
         );
-        form.setValue('leaderId', model.modal.payload?.squad?.leaderId || '');
-        form.setValue('sideId', model.modal.payload?.squad?.sideId || '');
+        form.setValue('leaderId', model.modal.payload?.squad?.leader?.id || '');
+        form.setValue('sideId', model.modal.payload?.squad?.side?.id || '');
         form.setValue(
           'activeCount',
           model.modal.payload?.squad?.activeCount || 0

--- a/src/features/squads/manage/ui.tsx
+++ b/src/features/squads/manage/ui.tsx
@@ -30,6 +30,8 @@ import {
   FixedCropperRef,
   ImageRestriction,
 } from 'react-advanced-cropper';
+import Image from 'next/image';
+import { Preloader } from '@/shared/ui/atoms/preloader';
 
 const ManageSquadModal: FC<
   PropsWithChildren<{
@@ -179,6 +181,8 @@ const ManageSquadModal: FC<
       }
     }, [model.modal.isOpen]);
 
+    const oldLogo = model.modal.payload?.squad?.logo?.url || '';
+
     return (
       <>
         <Dialog
@@ -193,150 +197,170 @@ const ManageSquadModal: FC<
               </DialogTitle>
             </DialogHeader>
 
-            <form
-              className='flex flex-col gap-2 overflow-hidden'
-              onSubmit={form.handleSubmit(onSubmit)}>
-              <div className='flex flex-col gap-2 '>
-                <input
-                  ref={imageRef}
-                  className='hidden'
-                  type='file'
-                  accept='image/png, image/jpeg, image/jpg, image/webp, image/gif'
-                  disabled={model.loader.isLoading}
-                  onChange={(e) => setFile(e.target.files?.[0] || null)}
-                />
-
-                {Boolean(image) && (
-                  <FixedCropper
-                    ref={cropperRef as RefObject<FixedCropperRef>}
-                    className='h-64'
-                    src={image}
-                    imageRestriction={ImageRestriction.stencil}
-                    stencilProps={{
-                      handlers: false,
-                      lines: true,
-                      movable: false,
-                      resizable: false,
-                    }}
-                    defaultSize={{
-                      height: 256,
-                      width: 256,
-                    }}
-                    stencilSize={{
-                      height: 256,
-                      width: 256,
-                    }}
+            <Preloader
+              isLoading={
+                model.loader.isLoading ||
+                model.users.pagination.preloader.isLoading ||
+                model.sides.pagination.preloader.isLoading
+              }>
+              <form
+                className='flex flex-col gap-2 overflow-hidden'
+                onSubmit={form.handleSubmit(onSubmit)}>
+                <div className='flex flex-col gap-2 '>
+                  <input
+                    ref={imageRef}
+                    className='hidden'
+                    type='file'
+                    accept='image/png, image/jpeg, image/jpg, image/webp, image/gif'
+                    disabled={model.loader.isLoading}
+                    onChange={(e) => setFile(e.target.files?.[0] || null)}
                   />
-                )}
 
-                {!image && <div className='size-64 mx-auto bg-black/80' />}
-                <Button
-                  type='button'
-                  className='w-64 mx-auto'
-                  variant={file ? 'outline' : 'default'}
-                  disabled={model.loader.isLoading}
-                  onClick={() => imageRef.current?.click()}>
-                  {file ? 'Змінити лого' : 'Обрати лого'}
-                </Button>
-              </div>
-
-              <div className='flex flex-col gap-2'>
-                <Controller
-                  control={form.control}
-                  name='name'
-                  render={({ field }) => (
-                    <Input
-                      {...field}
-                      placeholder='Назва загону'
-                      error={form.formState.errors.name?.message}
+                  {Boolean(image) && (
+                    <FixedCropper
+                      ref={cropperRef as RefObject<FixedCropperRef>}
+                      className='h-64 rounded-sm'
+                      src={image}
+                      imageRestriction={ImageRestriction.stencil}
+                      stencilProps={{
+                        handlers: false,
+                        lines: true,
+                        movable: false,
+                        resizable: false,
+                      }}
+                      defaultSize={{
+                        height: 256,
+                        width: 256,
+                      }}
+                      stencilSize={{
+                        height: 256,
+                        width: 256,
+                      }}
                     />
                   )}
-                />
 
-                <Controller
-                  control={form.control}
-                  name='tag'
-                  render={({ field }) => (
-                    <div className='flex flex-col gap-1'>
+                  {oldLogo && (
+                    <Image
+                      className='size-64 mx-auto object-cover rounded-sm'
+                      src={oldLogo}
+                      alt='Old logo'
+                      width={256}
+                      height={256}
+                    />
+                  )}
+
+                  {!image && !oldLogo && (
+                    <div className='size-64 mx-auto bg-black/80 rounded-sm' />
+                  )}
+                  <Button
+                    type='button'
+                    className='w-64 mx-auto'
+                    variant={file ? 'outline' : 'default'}
+                    disabled={model.loader.isLoading}
+                    onClick={() => imageRef.current?.click()}>
+                    {file || oldLogo ? 'Змінити лого' : 'Обрати лого'}
+                  </Button>
+                </div>
+
+                <div className='flex flex-col gap-4'>
+                  <Controller
+                    control={form.control}
+                    name='name'
+                    render={({ field }) => (
                       <Input
                         {...field}
-                        placeholder='Тег загону'
-                        error={form.formState.errors.tag?.message}
+                        label='Назва загону'
+                        error={form.formState.errors.name?.message}
                       />
-                      {tag && (
+                    )}
+                  />
+
+                  <Controller
+                    control={form.control}
+                    name='tag'
+                    render={({ field }) => (
+                      <div className='flex flex-col gap-1'>
+                        <Input
+                          {...field}
+                          label='Тег загону'
+                          error={form.formState.errors.tag?.message}
+                        />
+
                         <span className='text-sm text-neutral-500'>
                           Тег буде виглядати так: [{tag}]
                         </span>
-                      )}
-                    </div>
-                  )}
-                />
+                      </div>
+                    )}
+                  />
 
-                <Controller
-                  control={form.control}
-                  name='description'
-                  render={({ field }) => (
-                    <Input
-                      {...field}
-                      placeholder='Опис загону'
-                      error={form.formState.errors.description?.message}
-                    />
-                  )}
-                />
+                  <Controller
+                    control={form.control}
+                    name='description'
+                    render={({ field }) => (
+                      <Input
+                        {...field}
+                        label='Опис загону'
+                        error={form.formState.errors.description?.message}
+                      />
+                    )}
+                  />
 
-                <Controller
-                  control={form.control}
-                  name='sideId'
-                  render={({ field }) => (
-                    <Observer>
-                      {() => (
-                        <Select
-                          {...field}
-                          label='Сторона загону'
-                          options={model.sides.options}
-                          error={form.formState.errors.sideId?.message}
-                        />
-                      )}
-                    </Observer>
-                  )}
-                />
+                  <Controller
+                    control={form.control}
+                    name='sideId'
+                    render={({ field }) => (
+                      <Observer>
+                        {() => (
+                          <Select
+                            {...field}
+                            label='Сторона загону'
+                            options={model.sides.options}
+                            error={form.formState.errors.sideId?.message}
+                          />
+                        )}
+                      </Observer>
+                    )}
+                  />
 
-                <Controller
-                  control={form.control}
-                  name='leaderId'
-                  disabled={!sideId}
-                  render={({ field }) => (
-                    <Observer>
-                      {() => (
-                        <Select
-                          {...field}
-                          onSearch={(search) => {
-                            model.users.pagination.init({
-                              search,
-                              skip: 0,
-                              take: 100,
-                            });
-                          }}
-                          isLoading={model.users.pagination.preloader.isLoading}
-                          label='Лідер загону'
-                          options={model.users.options}
-                          error={form.formState.errors.sideId?.message}
-                        />
-                      )}
-                    </Observer>
-                  )}
-                />
-              </div>
+                  <Controller
+                    control={form.control}
+                    name='leaderId'
+                    disabled={!sideId}
+                    render={({ field }) => (
+                      <Observer>
+                        {() => (
+                          <Select
+                            {...field}
+                            onSearch={(search) => {
+                              model.users.pagination.init({
+                                search,
+                                skip: 0,
+                                take: 100,
+                              });
+                            }}
+                            isLoading={
+                              model.users.pagination.preloader.isLoading
+                            }
+                            label='Лідер загону'
+                            options={model.users.options}
+                            error={form.formState.errors.sideId?.message}
+                          />
+                        )}
+                      </Observer>
+                    )}
+                  />
+                </div>
 
-              <div className='flex justify-between mt-4'>
-                <Button variant='outline' onClick={() => model.modal.close()}>
-                  Скасувати
-                </Button>
-                <Button type='submit' disabled={!isValid}>
-                  {model?.modal?.payload?.squad ? 'Зберегти' : 'Створити'}
-                </Button>
-              </div>
-            </form>
+                <div className='flex justify-between mt-4'>
+                  <Button variant='outline' onClick={() => model.modal.close()}>
+                    Скасувати
+                  </Button>
+                  <Button type='submit' disabled={!isValid}>
+                    {model?.modal?.payload?.squad ? 'Зберегти' : 'Створити'}
+                  </Button>
+                </div>
+              </form>
+            </Preloader>
           </DialogContent>
         </Dialog>
 

--- a/src/features/user/ban-unban-user/ui.tsx
+++ b/src/features/user/ban-unban-user/ui.tsx
@@ -45,7 +45,7 @@ const BanUnbanUserModal: FC<
         <div className='flex flex-col gap-2'>
           {isBanAction && (
             <Input
-              placeholder='Час блокування'
+              label='Час блокування'
               type='datetime-local'
               onChange={(e) => setBanTime(e.target.value)}
             />

--- a/src/features/user/change-avatar/ui.tsx
+++ b/src/features/user/change-avatar/ui.tsx
@@ -23,9 +23,10 @@ import { Preloader } from '@/shared/ui/atoms/preloader';
 
 type ChangeAvatarModalProps = {
   model: ChangeAvatarModel;
+  autoInputClick?: boolean;
 };
 
-const ChangeAvatarModal = observer(({ model }: ChangeAvatarModalProps) => {
+const ChangeAvatarModal = observer(({ model, autoInputClick = false }: ChangeAvatarModalProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const cropperRef = useRef<CropperRef>(null);
   const [file, setFile] = useState<File | null>(null);
@@ -38,6 +39,12 @@ const ChangeAvatarModal = observer(({ model }: ChangeAvatarModalProps) => {
       setImage('');
     }
   }, [file]);
+
+  useEffect(() => {
+    if (autoInputClick && model.modal.isOpen) {
+      inputRef.current?.click();
+    }
+  }, [autoInputClick, model.modal.isOpen])
 
   return (
     <Dialog open={model.modal.isOpen} onOpenChange={model.modal.switch}>

--- a/src/features/user/change-avatar/ui.tsx
+++ b/src/features/user/change-avatar/ui.tsx
@@ -26,98 +26,118 @@ type ChangeAvatarModalProps = {
   autoInputClick?: boolean;
 };
 
-const ChangeAvatarModal = observer(({ model, autoInputClick = false }: ChangeAvatarModalProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const cropperRef = useRef<CropperRef>(null);
-  const [file, setFile] = useState<File | null>(null);
-  const [image, setImage] = useState('');
+const ChangeAvatarModal = observer(
+  ({ model, autoInputClick = false }: ChangeAvatarModalProps) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const cropperRef = useRef<CropperRef>(null);
+    const [file, setFile] = useState<File | null>(null);
+    const [image, setImage] = useState('');
 
-  useEffect(() => {
-    if (file) {
-      setImage(URL.createObjectURL(file));
-    } else {
-      setImage('');
-    }
-  }, [file]);
+    useEffect(() => {
+      if (file) {
+        setImage(URL.createObjectURL(file));
+      } else {
+        setImage('');
+      }
+    }, [file]);
 
-  useEffect(() => {
-    if (autoInputClick && model.modal.isOpen) {
-      inputRef.current?.click();
-    }
-  }, [autoInputClick, model.modal.isOpen])
+    useEffect(() => {
+      if (autoInputClick && model.modal.isOpen) {
+        // Use requestAnimationFrame to ensure DOM is ready after dialog opens
+        // Double RAF ensures the portal content is fully rendered
+        let rafId: number | undefined;
+        const frame1 = requestAnimationFrame(() => {
+          rafId = requestAnimationFrame(() => {
+            if (inputRef.current) {
+              inputRef.current.click();
+            }
+          });
+        });
 
-  return (
-    <Dialog open={model.modal.isOpen} onOpenChange={model.modal.switch}>
-      <DialogOverlay />
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className='text-lg font-bold'>
-            Змінити аватар
-          </DialogTitle>
-        </DialogHeader>
-        <div className='overflow-hidden'>
-          <Preloader isLoading={model.loader.isLoading}>
-            <div className='flex flex-col gap-2'>
-              <input
-                ref={inputRef}
-                className='hidden'
-                type='file'
-                disabled={model.loader.isLoading}
-                accept='image/png, image/jpeg, image/jpg, image/webp, image/gif'
-                onChange={(e) => setFile(e.target.files?.[0] || null)}
-              />
+        return () => {
+          cancelAnimationFrame(frame1);
+          if (rafId !== undefined) {
+            cancelAnimationFrame(rafId);
+          }
+        };
+      }
+    }, [autoInputClick, model.modal.isOpen]);
 
-              <Button
-                variant={file ? 'outline' : 'default'}
-                disabled={model.loader.isLoading}
-                onClick={() => inputRef.current?.click()}>
-                {file ? 'Змінити файл' : 'Обрати файл'}
-              </Button>
-
-              {image && (
-                <FixedCropper
-                  ref={cropperRef as RefObject<FixedCropperRef>}
-                  className='h-64'
-                  src={image}
-                  imageRestriction={ImageRestriction.stencil}
-                  stencilProps={{
-                    handlers: false,
-                    lines: true,
-                    movable: false,
-                    resizable: false,
-                  }}
-                  defaultSize={{
-                    height: 256,
-                    width: 256,
-                  }}
-                  stencilSize={{
-                    height: 256,
-                    width: 256,
-                  }}
-                />
-              )}
-
-              {image && (
-                <Button
+    return (
+      <Dialog open={model.modal.isOpen} onOpenChange={model.modal.switch}>
+        <DialogOverlay />
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className='text-lg font-bold'>
+              Змінити аватар
+            </DialogTitle>
+          </DialogHeader>
+          <div className='overflow-hidden'>
+            <Preloader isLoading={model.loader.isLoading}>
+              <div className='flex flex-col gap-2'>
+                <input
+                  ref={inputRef}
+                  className='hidden'
+                  type='file'
                   disabled={model.loader.isLoading}
-                  onClick={async () => {
-                    const base64 = cropperRef.current?.getCanvas()?.toDataURL();
+                  accept='image/png, image/jpeg, image/jpg, image/webp, image/gif'
+                  onChange={(e) => setFile(e.target.files?.[0] || null)}
+                />
 
-                    if (!base64) return;
-
-                    const file = await base64ToFile(base64, 'avatar');
-
-                    model.changeAvatar(file);
-                  }}>
-                  Зберегти
+                <Button
+                  variant={file ? 'outline' : 'default'}
+                  disabled={model.loader.isLoading}
+                  onClick={() => inputRef.current?.click()}>
+                  {file ? 'Змінити файл' : 'Обрати файл'}
                 </Button>
-              )}
-            </div>
-          </Preloader>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-});
+
+                {image && (
+                  <FixedCropper
+                    ref={cropperRef as RefObject<FixedCropperRef>}
+                    className='h-64'
+                    src={image}
+                    imageRestriction={ImageRestriction.stencil}
+                    stencilProps={{
+                      handlers: false,
+                      lines: true,
+                      movable: false,
+                      resizable: false,
+                    }}
+                    defaultSize={{
+                      height: 256,
+                      width: 256,
+                    }}
+                    stencilSize={{
+                      height: 256,
+                      width: 256,
+                    }}
+                  />
+                )}
+
+                {image && (
+                  <Button
+                    disabled={model.loader.isLoading}
+                    onClick={async () => {
+                      const base64 = cropperRef.current
+                        ?.getCanvas()
+                        ?.toDataURL();
+
+                      if (!base64) return;
+
+                      const file = await base64ToFile(base64, 'avatar');
+
+                      model.changeAvatar(file);
+                    }}>
+                    Зберегти
+                  </Button>
+                )}
+              </div>
+            </Preloader>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+);
 
 export { ChangeAvatarModal };

--- a/src/features/user/change-password/ui.tsx
+++ b/src/features/user/change-password/ui.tsx
@@ -53,14 +53,14 @@ const ChangePassword: FC<{
       onSubmit={form.handleSubmit(onSubmit)}>
       <Input
         {...form.register('oldPassword')}
-        placeholder='Старий пароль'
+        label='Старий пароль'
         type='password'
         error={form.formState.errors.oldPassword?.message}
         disabled={isSubmitting}
       />
       <Input
         {...form.register('newPassword')}
-        placeholder='Новий пароль'
+        label='Новий пароль'
         type='password'
         error={form.formState.errors.newPassword?.message}
         disabled={isSubmitting}

--- a/src/shared/sdk/index.tsx
+++ b/src/shared/sdk/index.tsx
@@ -198,7 +198,22 @@ class ApiModel {
   };
 
   updateSquad = async ({ id, ...dto }: UpdateSquadDto) => {
-    return await this.instance.patch<Squad>(`/squads/${id}`, dto);
+    const formData = new FormData();
+
+    Object.entries(dto).forEach(([key, value]) => {
+      if (value) {
+        formData.append(
+          key,
+          typeof value === 'number' ? value.toString() : value
+        );
+      }
+    });
+
+    return await this.instance.patch<Squad>(`/squads/${id}`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
   };
 
   deleteSquad = async (squadId: string) => {

--- a/src/shared/sdk/index.tsx
+++ b/src/shared/sdk/index.tsx
@@ -154,8 +154,11 @@ class ApiModel {
     return await this.instance.post('/users/sign-up/confirm', { token });
   };
 
-  login = async (dto: LoginDto) => {
-    return await this.instance.post<LoginResponse>('/users/login', dto);
+  login = async ({ email, password }: LoginDto) => {
+    return await this.instance.post<LoginResponse>('/users/login', {
+      emailOrNickname: email,
+      password,
+    });
   };
 
   refreshToken = async (dto: RefreshTokenDto) => {

--- a/src/shared/ui/atoms/input/index.tsx
+++ b/src/shared/ui/atoms/input/index.tsx
@@ -3,13 +3,13 @@ import { cn } from '@/shared/utils/cn';
 import { SearchIcon, X } from 'lucide-react';
 
 import { formatNumericValue } from '@/shared/utils/string';
-import classNames from 'classnames';
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   searchIcon?: boolean;
   closeIcon?: boolean;
   error?: string;
+  label?: string;
   mapSetValue?: (value: string) => string;
 }
 
@@ -68,6 +68,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       closeIcon,
       error,
       mapSetValue,
+      label,
       ...props
     },
     ref
@@ -88,6 +89,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       setValue(propValue || '');
     }, [propValue]);
 
+    const [isFocused, setIsFocused] = React.useState(props.autoFocus || false);
+
     return (
       <div className='relative w-full'>
         {searchIcon && (
@@ -99,13 +102,29 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           />
         )}
 
+        {label && (
+          <label
+            className={cn(
+              'absolute left-2 -translate-y-1/2 text-muted-foreground transition-transform text-foreground top-0 bg-primary px-2 text-xs rounded-lg'
+            )}>
+            {label}
+          </label>
+        )}
         <input
           ref={ref}
           type={type}
           value={value}
           onChange={handleChange}
+          onFocus={(e) => {
+            setIsFocused(true);
+            props.onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setIsFocused(false);
+            props.onBlur?.(e);
+          }}
           className={cn(
-            'flex h-9 w-full focus:border border border-primary px-2 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-45 text-muted-foreground bg-accent/80',
+            'rounded-sm outline-none focus:outline-none flex h-9 w-full border border-primary px-2 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45 text-muted-foreground bg-accent/80',
             {
               'pl-9': searchIcon,
             },
@@ -131,7 +150,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           </button>
         )}
 
-        {error && <p className='mt-1 text-red-500 text-sm'>{error}</p>}
+        {error && (
+          <p className='absolute -translate-y-1/2 top-0 right-2 text-destructive bg-red-950 text-xs text-right px-2 rounded-lg'>
+            {error}
+          </p>
+        )}
       </div>
     );
   }

--- a/src/shared/ui/atoms/select/index.tsx
+++ b/src/shared/ui/atoms/select/index.tsx
@@ -83,13 +83,17 @@ const Select: FC<SingleSelectProps | MultipleSelectProps> = ({
         children ? (
           children
         ) : (
-          <div className='flex flex-col w-full'>
+          <div className='relative flex flex-col w-full'>
+            {label && (
+              <div className='bg-primary px-2 text-xs rounded-lg text-muted-foreground/50 absolute left-2 top-0 -translate-y-1/2'>
+                {label}
+              </div>
+            )}
             <div
               className={cn(
-                'cursor-pointer flex items-center text-muted-foreground/50 h-9 w-full focus:border border border-primary px-2 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-45 text-muted-foreground bg-accent/80 hover:bg-primary/15',
+                'cursor-pointer flex items-center text-muted-foreground/50 h-9 w-full focus:border border border-primary px-2 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-45 text-muted-foreground bg-accent/80 hover:bg-primary/15 rounded-sm',
                 { 'text-muted-foreground/50': !value || !value.length }
               )}>
-              {!value?.length && label}
               {multiple
                 ? combinedOptions
                     .filter((v) => value?.includes(v.value))
@@ -99,7 +103,11 @@ const Select: FC<SingleSelectProps | MultipleSelectProps> = ({
 
               <ChevronDownIcon className='size-4 ml-auto' />
             </div>
-            {error && <p className='mt-1 text-red-500 text-sm'>{error}</p>}
+            {error && (
+              <p className='absolute -translate-y-1/2 top-0 right-2 text-destructive bg-red-950 text-xs text-right px-2 rounded-lg'>
+                {error}
+              </p>
+            )}
           </div>
         )
       }>
@@ -109,6 +117,7 @@ const Select: FC<SingleSelectProps | MultipleSelectProps> = ({
             className='border-t-0 border-b-1 border-x-0 outline-0'
             placeholder='Пошук'
             searchIcon
+            error={error}
             onChange={(e) => onSearch(e.target.value)}
           />
         )}

--- a/src/widgets/layout/footer/index.tsx
+++ b/src/widgets/layout/footer/index.tsx
@@ -3,13 +3,11 @@ import { Social } from '@/features/social/ui';
 export const Footer = () => (
   <footer className='mt-auto flex justify-center items-center bg-card min-h-24'>
     <div className='w-full flex justify-between items-center container max-lg:flex-col max-lg:gap-4 max-lg:pb-4'>
-      <div className='social'></div>
-      <div className='copyright'>
+      <div />
+      <div className='min-lg:ml-[168px]'>
         Virtual Tactical Games. Всі права захищені.
       </div>
-      <div className='links'>
-        <Social />
-      </div>
+      <Social />
     </div>
   </footer>
 );

--- a/src/widgets/layout/header/index.tsx
+++ b/src/widgets/layout/header/index.tsx
@@ -173,7 +173,7 @@ export const MobileMenu = observer(() => {
   return (
     <div
       className={cn(
-        'absolute top-0 left-0 w-screen h-screen bg-neutral-900 z-50 transition-all duration-300 flex flex-col',
+        'fixed top-0 left-0 w-screen h-screen bg-neutral-900 z-50 transition-all duration-300 flex flex-col',
         {
           'translate-x-full': !headerModel.mobileMenu.isOpen,
         }

--- a/src/widgets/layout/header/index.tsx
+++ b/src/widgets/layout/header/index.tsx
@@ -30,6 +30,7 @@ import { env } from '@/shared/config/env';
 import { Social } from '@/features/social/ui';
 import { useRouter } from 'next/navigation';
 import { headerModel } from './model';
+import { UserNicknameText } from '@/entities/user/ui/user-text';
 
 export type HeaderProps = {
   enableScrollVisibility?: boolean;
@@ -118,7 +119,7 @@ const AuthLinks: FC<{ className?: string; activeClassName?: string }> =
                     'gap-3 border-none bg-transparent hover:bg-transparent'
                   )}>
                   <Avatar size='sm' src={session.user?.user?.avatar?.url} />
-                  {session.user?.user?.nickname}
+                  <UserNicknameText user={session.user?.user} />
                 </Button>
               }>
               <NextLink

--- a/src/widgets/layout/header/index.tsx
+++ b/src/widgets/layout/header/index.tsx
@@ -116,7 +116,7 @@ const AuthLinks: FC<{ className?: string; activeClassName?: string }> =
               trigger={
                 <Button
                   className={cn(
-                    'gap-3 border-none bg-transparent hover:bg-transparent'
+                    'gap-3 border-none bg-transparent hover:bg-primary/50 min-w-40'
                   )}>
                   <Avatar size='sm' src={session.user?.user?.avatar?.url} />
                   <UserNicknameText user={session.user?.user} />
@@ -146,7 +146,6 @@ const AuthLinks: FC<{ className?: string; activeClassName?: string }> =
                   e.preventDefault();
 
                   session.logout();
-                  router.push(ROUTES.auth.login);
                 }}>
                 <Button
                   align='left'
@@ -169,6 +168,10 @@ export const MobileMenu = observer(() => {
       ? 'hidden'
       : 'auto';
   }, [headerModel.mobileMenu.isOpen]);
+
+  useEffect(() => {
+    return () => headerModel.mobileMenu.close();
+  }, []);
 
   return (
     <div
@@ -195,7 +198,7 @@ export const MobileMenu = observer(() => {
         </div>
       </div>
 
-      <ScheduleInfo className='my-2 mx-auto' />
+      <ScheduleInfo className='my-2 mx-auto' version='full' />
 
       <div className='flex flex-col'>
         <MainLinks
@@ -210,10 +213,7 @@ export const MobileMenu = observer(() => {
         </div>
       </div>
 
-      <Social
-        className='mt-10 mx-auto mb-8 justify-center gap-10 w-full px-4'
-        size={24}
-      />
+      <Social className='mt-10 mx-auto mb-8 justify-center gap-10 w-full px-4' />
     </div>
   );
 });
@@ -276,8 +276,12 @@ export const Header: FC<HeaderProps> = observer(
               </div>
             </View.Condition>
             <div className='flex items-center justify-between gap-7 mx-4'>
-              <Social size={24} />
-              <ScheduleInfo className='mr-4 hidden lg:flex' />
+              <Social iconClassName='size-4' />
+              <ScheduleInfo className='mr-4 hidden min-xl:flex' />
+              <ScheduleInfo
+                className='my-2 mx-auto hidden max-xl:flex'
+                version='short'
+              />
               <View.Condition if={!session.preloader.isLoading}>
                 <AuthLinks />
               </View.Condition>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces labeled inputs and error badges, squad logo upload/cropping with selective updates, stronger auth flows (login by nickname/email, stricter passwords, token refresh hardening), and header/footer + schedule/social UI refinements.
> 
> - **UI/Form Components**
>   - Add `label` support and inline error badges to `Input` and `Select` (`src/shared/ui/atoms/input`, `select`).
>   - Replace placeholders with labels across auth/server forms; minor styling tweaks (rounded, `paper` utility in `globals.css`).
> - **Auth**
>   - Login now accepts nickname or email via `emailOrNickname` (`sdk.login`); stricter password validation in `forgot-password-confirm`.
>   - Improved token refresh: prevent concurrent refresh, handle failures, clear cookies on error (`src/shared/sdk/index.tsx`).
> - **Users/Profile**
>   - Use `UserNicknameText` with side tag in admin and profile pages.
>   - Avatar change modal auto-opens file dialog and UX improvements; profile avatar rounded (`profile/page.tsx`, `change-avatar`).
>   - Ban dialog adds datetime input label; change-password uses labels.
> - **Squads**
>   - Manage modal: logo upload with cropper, preview old logo; selective `UpdateSquadDto`; preloaders; leader/side fixes.
>   - `api.updateSquad` switched to multipart `FormData`.
>   - Squads page/layout uses `paper` utility; user squad shows squad logo (larger).
> - **Layout/Navigation**
>   - Header: improved auth popover (nickname component), mobile menu fixed positioning, schedule info short/full variants, smaller social icons.
>   - Footer: simplified structure and social placement.
> - **Misc**
>   - `ScheduleInfo` supports `version` prop; `Social` accepts `iconClassName`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e1f0ecfcffaa1d78087bc2d0ead867605255a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->