### PR TITLE
feat: migrate to Inter font, refactor global typography & UI spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,204 +1,139 @@
-@import 'tailwindcss';
-@import 'react-advanced-cropper/dist/style.css';
+@import "tailwindcss";
+@import "react-advanced-cropper/dist/style.css";
+
 @theme {
-  --font-sans: var(--font-inter), sans-serif;
-  --color-card: #1f1f1f;
-  --color-primary: var(--color-lime-700);
+  --font-sans: "Inter", sans-serif;
+
+  --color-card:         #1f1f1f;
+  --color-primary:      #4d7c0f;
   --color-text-primary: #799a63;
-  --color-foreground: #ffffff;
-  --color-muted: #eee;
-  --color-destructive: #ff0000;
+  --color-foreground:   #ffffff;
+  --color-muted:        #eeeeee;
+  --color-destructive:  #ff0000;
 
-  /* Custom Legible Type Scale: minimum text size of 13px (xs) and 14px (sm) */
-  --font-size-xs: 0.8125rem; /* 13px */
-  --font-size-sm: 0.875rem; /* 14px */
-  --font-size-base: 1rem; /* 16px */
-  --font-size-lg: 1.125rem; /* 18px */
-  --font-size-xl: 1.25rem; /* 20px */
-  --font-size-2xl: 1.5rem; /* 24px */
-  --font-size-3xl: 1.875rem; /* 30px */
-  --font-size-4xl: 2.25rem; /* 36px */
-  --font-size-5xl: 3rem; /* 48px */
+  --font-size-xs:   0.8125rem;
+  --font-size-sm:   0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg:   1.125rem;
+  --font-size-xl:   1.25rem;
+  --font-size-2xl:  1.5rem;
+  --font-size-3xl:  1.875rem;
+  --font-size-4xl:  2.25rem;
+  --font-size-5xl:  3rem;
 }
 
-@utility paper {
-  border-color: rgba(255, 255, 255, 0.1);
-  background-color: rgba(0, 0, 0, 0.4);
-  border-width: 1px;
-  border-style: solid;
-  border-radius: var(--radius-xl);
-  backdrop-filter: blur(10px);
-  backdrop-filter: blur(var(--blur-sm));
-}
-
-* {
-  scroll-behavior: smooth;
-  box-sizing: border-box;
-  scroll-padding-top: 80px;
-}
-
-body {
-  font-family: var(--font-sans);
-  color: var(--color-zinc-300); /* Soft light gray to prevent eye strain on dark background */
-  background: url('/images/bg.jpeg') no-repeat center center fixed;
-  background-size: cover;
-  line-height: 1.6;
-  font-size: var(--text-base); /* 16px */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-/* Global Paragraph & List Elements */
-p, li, dd {
-  color: var(--color-zinc-300);
-  line-height: 1.6; /* Airier, highly legible line-height for body content */
-}
-
-/* Global Headings Reset & Type Scale */
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-sans);
-  color: #ffffff; /* Keep titles high contrast crisp pure white as requested */
-  font-weight: 700;
-  line-height: 1.22; /* Sleek, tight line-height to avoid scattering multi-line headings */
-  letter-spacing: -0.025em;
-}
-
-h1 {
-  font-size: var(--text-3xl); /* 30px */
-  letter-spacing: -0.03em;
-}
-
-h2 {
-  font-size: var(--text-2xl); /* 24px */
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-h3 {
-  font-size: var(--text-xl); /* 20px */
-  font-weight: 600;
-  letter-spacing: -0.015em;
-}
-
-h4 {
-  font-size: var(--text-lg); /* 18px */
-  font-weight: 600;
-}
-
-h5 {
-  font-size: var(--text-base); /* 16px */
-  font-weight: 600;
-}
-
-h6 {
-  font-size: var(--text-sm); /* 14px */
-  font-weight: 600;
-}
-
-/* Mobile-First Adaptivity for Body and Headings */
-@media (max-width: 768px) {
-  body, p, li, dd {
-    font-size: 0.9375rem; /* 15px on mobile screens */
-    line-height: 1.55;
+@layer base {
+  :root {
+    --font-sans: var(--font-inter, "Inter"), sans-serif;
   }
 
-  h1 {
-    font-size: var(--text-2xl); /* scale down on mobile to prevent line-breaks */
-    letter-spacing: -0.02em;
-  }
-  
-  h2 {
-    font-size: var(--text-xl);
-    letter-spacing: -0.015em;
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    scroll-behavior: smooth;
+    scroll-padding-top: 80px;
   }
 
-  h3 {
-    font-size: var(--text-lg);
+  body {
+    font-family: var(--font-sans);
+    font-size: var(--font-size-base);
+    color: var(--color-zinc-300);
+    background: url("/images/bg.jpeg") no-repeat center center fixed;
+    background-size: cover;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
-  h4 {
-    font-size: var(--text-base);
+  p, li, dd {
+    color: var(--color-zinc-300);
+    line-height: 1.6;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    color: #ffffff;
+    line-height: 1.22;
+    letter-spacing: -0.025em;
+  }
+
+  h1 { font-size: var(--font-size-3xl);  letter-spacing: -0.03em; }
+  h2 { font-size: var(--font-size-2xl);  font-weight: 600; letter-spacing: -0.02em; }
+  h3 { font-size: var(--font-size-xl);   font-weight: 600; letter-spacing: -0.015em; }
+  h4 { font-size: var(--font-size-lg);   font-weight: 600; }
+  h5 { font-size: var(--font-size-base); font-weight: 600; }
+  h6 { font-size: var(--font-size-sm);   font-weight: 600; }
+
+  button, [data-slot="button"] {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    line-height: 1;
+  }
+
+  input, textarea, select {
+    font-family: var(--font-sans);
+    font-size: var(--font-size-sm);
+    letter-spacing: 0.01em;
+    line-height: 1.5;
+  }
+
+  textarea {
+    line-height: 1.6;
+    padding: 0.625rem 0.75rem;
+  }
+
+  a {
+    letter-spacing: 0.01em;
+    transition: color 0.15s ease, opacity 0.15s ease;
+  }
+
+  a:hover, a:active {
+    color: var(--color-text-primary);
+  }
+
+  ::-webkit-scrollbar       { width: 8px; }
+  ::-webkit-scrollbar-track { background: #000; }
+  ::-webkit-scrollbar-thumb { background: #888; }
+
+  @media (max-width: 768px) {
+    body, p, li, dd {
+      font-size: 0.9375rem;
+      line-height: 1.55;
+    }
+
+    h1 { font-size: var(--font-size-2xl); letter-spacing: -0.02em; }
+    h2 { font-size: var(--font-size-xl);  letter-spacing: -0.015em; }
+    h3 { font-size: var(--font-size-lg); }
+    h4 { font-size: var(--font-size-base); }
   }
 }
 
-/* ============================================================
-   Context Element Enhancements
-   — No !important: components own their own styles.
-     These are base-layer defaults for bare HTML elements.
-   ============================================================ */
+@layer components {
+  .paper {
+    background-color: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(var(--blur-sm, 4px));
+  }
 
-/* Buttons: pixel-perfect vertical centering via leading-none.
-   The Button atom already handles this; this covers bare <button> tags. */
-button,
-[data-slot="button"] {
-  font-family: var(--font-sans);
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  line-height: 1; /* = leading-none: collapses line-height so padding controls height */
-}
+  .label-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
 
-/* Inputs & Textareas: consistent font, gentle tracking, airy line-height */
-input,
-textarea,
-select {
-  font-family: var(--font-sans);
-  font-size: 0.875rem; /* 14px — legible without competing with body copy */
-  letter-spacing: 0.01em;
-  line-height: 1.5;
-}
+  .text-body {
+    color: var(--color-zinc-300);
+    line-height: 1.6;
+  }
 
-/* Textarea specifically benefits from slightly more line-height for multi-line readability */
-textarea {
-  line-height: 1.6;
-  padding: 0.625rem 0.75rem; /* py-2.5 px-3 — mirrors the input padding */
-}
-
-/* Floating label badges (e.g. inside Input component) */
-.label-badge {
-  font-family: var(--font-sans);
-  font-weight: 600;
-  font-size: 0.75rem; /* 12px */
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-/* Links & Nav Elements Spacing */
-a {
-  font-family: var(--font-sans);
-  letter-spacing: 0.01em;
-  transition: color 0.15s ease, opacity 0.15s ease;
-}
-
-/* Global Premium Typography Overrides */
-.body-text,
-.description-text {
-  color: var(--color-zinc-300) !important;
-  line-height: 1.6 !important;
-}
-
-.heading-premium {
-  color: #ffffff !important;
-  line-height: 1.22 !important;
-  font-weight: 700 !important;
-}
-
-a:hover {
-  color: var(--color-text-primary);
-}
-
-a:active {
-  color: var(--color-text-primary);
-}
-
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: #000000;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #888;
+  .text-heading {
+    color: #ffffff;
+    font-weight: 700;
+    line-height: 1.22;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,24 @@
 @import 'tailwindcss';
 @import 'react-advanced-cropper/dist/style.css';
 @theme {
+  --font-sans: var(--font-inter), sans-serif;
   --color-card: #1f1f1f;
   --color-primary: var(--color-lime-700);
   --color-text-primary: #799a63;
   --color-foreground: #ffffff;
   --color-muted: #eee;
   --color-destructive: #ff0000;
+
+  /* Custom Legible Type Scale: minimum text size of 13px (xs) and 14px (sm) */
+  --font-size-xs: 0.8125rem; /* 13px */
+  --font-size-sm: 0.875rem; /* 14px */
+  --font-size-base: 1rem; /* 16px */
+  --font-size-lg: 1.125rem; /* 18px */
+  --font-size-xl: 1.25rem; /* 20px */
+  --font-size-2xl: 1.5rem; /* 24px */
+  --font-size-3xl: 1.875rem; /* 30px */
+  --font-size-4xl: 2.25rem; /* 36px */
+  --font-size-5xl: 3rem; /* 48px */
 }
 
 @utility paper {
@@ -26,10 +38,148 @@
 }
 
 body {
-  font-family: 'Roboto Condensed', 'Roboto Condensed Fallback"';
-  color: var(--color-foreground);
+  font-family: var(--font-sans);
+  color: var(--color-zinc-300); /* Soft light gray to prevent eye strain on dark background */
   background: url('/images/bg.jpeg') no-repeat center center fixed;
   background-size: cover;
+  line-height: 1.6;
+  font-size: var(--text-base); /* 16px */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Global Paragraph & List Elements */
+p, li, dd {
+  color: var(--color-zinc-300);
+  line-height: 1.6; /* Airier, highly legible line-height for body content */
+}
+
+/* Global Headings Reset & Type Scale */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-sans);
+  color: #ffffff; /* Keep titles high contrast crisp pure white as requested */
+  font-weight: 700;
+  line-height: 1.22; /* Sleek, tight line-height to avoid scattering multi-line headings */
+  letter-spacing: -0.025em;
+}
+
+h1 {
+  font-size: var(--text-3xl); /* 30px */
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  font-size: var(--text-2xl); /* 24px */
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+h3 {
+  font-size: var(--text-xl); /* 20px */
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+h4 {
+  font-size: var(--text-lg); /* 18px */
+  font-weight: 600;
+}
+
+h5 {
+  font-size: var(--text-base); /* 16px */
+  font-weight: 600;
+}
+
+h6 {
+  font-size: var(--text-sm); /* 14px */
+  font-weight: 600;
+}
+
+/* Mobile-First Adaptivity for Body and Headings */
+@media (max-width: 768px) {
+  body, p, li, dd {
+    font-size: 0.9375rem; /* 15px on mobile screens */
+    line-height: 1.55;
+  }
+
+  h1 {
+    font-size: var(--text-2xl); /* scale down on mobile to prevent line-breaks */
+    letter-spacing: -0.02em;
+  }
+  
+  h2 {
+    font-size: var(--text-xl);
+    letter-spacing: -0.015em;
+  }
+
+  h3 {
+    font-size: var(--text-lg);
+  }
+
+  h4 {
+    font-size: var(--text-base);
+  }
+}
+
+/* ============================================================
+   Context Element Enhancements
+   — No !important: components own their own styles.
+     These are base-layer defaults for bare HTML elements.
+   ============================================================ */
+
+/* Buttons: pixel-perfect vertical centering via leading-none.
+   The Button atom already handles this; this covers bare <button> tags. */
+button,
+[data-slot="button"] {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  line-height: 1; /* = leading-none: collapses line-height so padding controls height */
+}
+
+/* Inputs & Textareas: consistent font, gentle tracking, airy line-height */
+input,
+textarea,
+select {
+  font-family: var(--font-sans);
+  font-size: 0.875rem; /* 14px — legible without competing with body copy */
+  letter-spacing: 0.01em;
+  line-height: 1.5;
+}
+
+/* Textarea specifically benefits from slightly more line-height for multi-line readability */
+textarea {
+  line-height: 1.6;
+  padding: 0.625rem 0.75rem; /* py-2.5 px-3 — mirrors the input padding */
+}
+
+/* Floating label badges (e.g. inside Input component) */
+.label-badge {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.75rem; /* 12px */
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* Links & Nav Elements Spacing */
+a {
+  font-family: var(--font-sans);
+  letter-spacing: 0.01em;
+  transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+/* Global Premium Typography Overrides */
+.body-text,
+.description-text {
+  color: var(--color-zinc-300) !important;
+  line-height: 1.6 !important;
+}
+
+.heading-premium {
+  color: #ffffff !important;
+  line-height: 1.22 !important;
+  font-weight: 700 !important;
 }
 
 a:hover {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Roboto_Condensed } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Toaster } from 'react-hot-toast';
 
 import './globals.css';
@@ -7,9 +7,9 @@ import { SessionProvider } from '@/entities/session/provider';
 
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
-const robotoCondensed = Roboto_Condensed({
-  variable: '--font-roboto-condensed',
-  subsets: ['latin'],
+const inter = Inter({
+  variable: '--font-inter',
+  subsets: ['latin', 'cyrillic'],
 });
 
 export const metadata: Metadata = {
@@ -49,7 +49,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-title" content="VTG" />
         <link rel="manifest" href="/images/favicon/site.webmanifest" />
       </head>
-      <body className={`${robotoCondensed.variable} antialiased`}>
+      <body className={`${inter.variable} antialiased`}>
         <Toaster
           position="bottom-center"
           toastOptions={{

--- a/src/shared/ui/atoms/button/index.tsx
+++ b/src/shared/ui/atoms/button/index.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/utils/cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border text-sm font-semibold leading-none transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer',
   {
     variants: {
       variant: {
@@ -24,10 +24,10 @@ const buttonVariants = cva(
         right: 'justify-end',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 gap-1.5 px-3 has-[>svg]:px-2.5 text-sm',
-        lg: 'h-10 px-6 has-[>svg]:px-4 text-lg',
-        icon: 'size-9',
+        default: 'py-2.5 px-5 has-[>svg]:px-4 text-sm',
+        sm: 'py-2 px-3.5 has-[>svg]:px-2.5 gap-1.5 text-sm',
+        lg: 'py-3.5 px-8 has-[>svg]:px-6 text-base md:text-lg',
+        icon: 'p-2.5 aspect-square',
       },
     },
     defaultVariants: {

--- a/src/shared/ui/atoms/input/index.tsx
+++ b/src/shared/ui/atoms/input/index.tsx
@@ -72,7 +72,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="relative w-full">
         {searchIcon && (
-          <SearchIcon className={cn('absolute left-3 top-4.5 -translate-y-1/2 text-muted-foreground', 'h-4 w-4')} />
+          <SearchIcon className={cn('absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground', 'h-4 w-4')} />
         )}
 
         {label && (
@@ -97,7 +97,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             props.onBlur?.(e);
           }}
           className={cn(
-            'flex h-9 w-full rounded-md border border-neutral-700 bg-black/70 px-2 py-1 text-sm text-zinc-100 shadow-sm transition-colors placeholder:text-zinc-500 focus-visible:border-lime-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-500/40 disabled:cursor-not-allowed disabled:opacity-45',
+            'flex w-full rounded-md border border-neutral-700 bg-black/70 px-3 py-2.5 text-sm leading-none text-zinc-100 shadow-sm transition-colors placeholder:text-zinc-500 focus-visible:border-lime-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-500/40 disabled:cursor-not-allowed disabled:opacity-45',
             {
               'pl-9': searchIcon,
             },

--- a/src/widgets/layout/header/index.tsx
+++ b/src/widgets/layout/header/index.tsx
@@ -270,7 +270,7 @@ export const MobileMenu = observer(() => {
           <button
             type="button"
             aria-label="Закрити меню"
-            className="inline-flex size-9 items-center justify-center rounded-full border border-white/10 bg-black/60 text-zinc-200 shadow-md transition-colors hover:bg-white/10"
+            className="inline-flex items-center justify-center rounded-full border border-white/10 bg-black/60 p-2 text-zinc-200 shadow-md transition-colors hover:bg-white/10"
             onClick={headerModel.mobileMenu.close}>
             <XIcon className="h-5 w-5" />
           </button>
@@ -286,10 +286,10 @@ export const MobileMenu = observer(() => {
             <div className="border-b border-white/10 pb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-zinc-400">
               Навігація
             </div>
-            <div className="mt-2 flex flex-col">
+            <div className="mt-2 flex flex-col gap-0.5">
               <MainLinks
-                className="block px-2 py-2 text-sm font-medium text-zinc-100 hover:bg-white/5 rounded-md"
-                activeClassName="bg-primary text-white rounded-md"
+                className="inline-flex items-center leading-none rounded-md px-3 py-2.5 text-sm font-semibold text-zinc-100 hover:bg-white/5"
+                activeClassName="bg-primary/90 text-white"
               />
             </div>
           </nav>
@@ -300,10 +300,10 @@ export const MobileMenu = observer(() => {
                 <div className="border-b border-white/10 pb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-zinc-400">
                   Обліковий запис
                 </div>
-                <div className="mt-3 flex flex-col gap-2">
+                <div className="mt-3 flex flex-col gap-1">
                   <AuthLinks
-                    className="block w-full rounded-md px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-primary/80 hover:text-white text-center"
-                    activeClassName="bg-primary text-white rounded-md"
+                    className="inline-flex w-full items-center justify-center leading-none rounded-md px-3 py-2.5 text-sm font-semibold text-zinc-100 hover:bg-primary/80 hover:text-white"
+                    activeClassName="bg-primary/90 text-white"
                   />
                 </div>
               </div>
@@ -367,9 +367,9 @@ export const Header: FC<HeaderProps> = observer(({ enableScrollVisibility = fals
         </Link>
 
         <div className="mx-auto flex items-center justify-between w-full max-lg:hidden">
-          <div className="mr-auto flex items-center justify-between gap-3">
+          <div className="mr-auto flex items-center justify-between gap-1">
             <MainLinks
-              className="rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200 transition-colors hover:bg-white/10 hover:text-white"
+              className="inline-flex items-center leading-none rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200 transition-colors hover:bg-white/10 hover:text-white"
               activeClassName="bg-primary/90 text-white rounded-md"
             />
           </div>
@@ -380,7 +380,7 @@ export const Header: FC<HeaderProps> = observer(({ enableScrollVisibility = fals
             <ScheduleInfo className="my-2 mx-auto hidden max-2xl:flex" version="short" />
 
             <AuthLinks
-              className="rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200 transition-colors hover:bg-primary/90 hover:text-white"
+              className="inline-flex items-center leading-none rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200 transition-colors hover:bg-primary/90 hover:text-white"
               activeClassName="bg-primary/90 text-white rounded-md"
             />
           </div>


### PR DESCRIPTION
- Replace Roboto Condensed with Inter (latin + cyrillic)
- Add responsive type scale (h1-h6, body, p, li) in globals.css
- Remove fixed heights from Button, use padding-only sizing + leading-none
- Fix Input: drop h-9, use py-2.5 px-3 + leading-none
- Update header nav links: inline-flex items-center leading-none
- Remove !important overrides from CSS context rules
- Fine-tune installation guide typography and button spacing